### PR TITLE
fix: gracefully handle unavailable alarms endpoint during fetch and s…

### DIFF
--- a/webapp/src/app/devices/fridge/settings/settings.component.ts
+++ b/webapp/src/app/devices/fridge/settings/settings.component.ts
@@ -126,7 +126,12 @@ export class FridgeSettingComponent implements OnInit {
         "externalfan": device_settings.fans?.external == null ? 100 : device_settings.fans?.external,
       }
 
-      this.alarms = await this.devices.getAlarms(this.device_id);
+      try {
+        this.alarms = await this.devices.getAlarms(this.device_id);
+      } catch (err) {
+        console.warn('Alarms endpoint unavailable, continuing without alarms.', err);
+        this.alarms = [];
+      }
 
       console.log(device_settings.daynight.float_start)
       console.log(this.settings.daynight.float_start)
@@ -239,7 +244,13 @@ export class FridgeSettingComponent implements OnInit {
 
     this.saving = true;
     await this.devices.setSettings(this.device_id, JSON.stringify(device_settings))
-    await this.devices.setAlarms(this.device_id, this.alarms)
+    if (Array.isArray(this.alarms) && this.alarms.length > 0) {
+      try {
+        await this.devices.setAlarms(this.device_id, this.alarms)
+      } catch (err) {
+        console.warn('Alarms endpoint unavailable, skipping alarm save.', err);
+      }
+    }
     this.saved = true;
     setTimeout(() => {
       this.saving = false;


### PR DESCRIPTION
Bei mir geht die Alarm Route irgendwie nicht. Habe mal ein try catch hinzugefügt damit die settings trotzdem funktionieren
<img width="1876" height="224" alt="Screenshot from 2025-10-31 14-36-20" src="https://github.com/user-attachments/assets/a5b5d62f-fe94-4355-8f0c-520bcd75e5b2" />

