### PR TITLE
Fix connection timeout: 15-min offline watchdog + stop WiFi thrashing on MQTT failure

### DIFF
--- a/firmware/src/fridgecloud.cpp
+++ b/firmware/src/fridgecloud.cpp
@@ -4,7 +4,6 @@
 #include <EspMQTTClient.h>
 #include <HTTPClient.h>
 #include <WiFiClient.h>
-#include <WiFi.h>
 #include <esp_task_wdt.h>
 #include <esp_system.h>
 
@@ -349,14 +348,6 @@ namespace fg {
     if(++publish_failure_count >= MAX_PUBLISH_FAILURES) {
       Serial.println("forcing mqtt reconnect after repeated publish failures");
       client->forceDisconnect();
-      // Repeated MQTT publish failures with errno 11 usually mean LWIP is
-      // out of socket/send buffers, not that the MQTT credentials are bad.
-      // Kick the station reconnect path so the TCP/IP stack gets a chance to
-      // release stale resources instead of keeping the half-dead socket alive.
-      if(WiFi.isConnected()) {
-        WiFi.disconnect(false, false);
-        WiFi.reconnect();
-      }
       publish_failure_count = 0;
       connected = false;
     }

--- a/firmware/src/fridgecloud.h
+++ b/firmware/src/fridgecloud.h
@@ -115,6 +115,7 @@ namespace fg {
     void handleTunnelReads();
     void notePublishFailure();
     inline bool directMode() { return custom_mqtt; }
+    inline bool isConnected() const { return connected; }
   };
 
 }

--- a/firmware/src/main.cpp
+++ b/firmware/src/main.cpp
@@ -49,6 +49,14 @@ static const char* resetReasonStr(esp_reset_reason_t r) {
 // the health log once MQTT is up.
 static esp_reset_reason_t g_last_reset_reason = ESP_RST_UNKNOWN;
 
+// Survives a software reset (ESP.restart()) but is cleared on power-on.
+// Set to true just before a connection-watchdog reboot so the next boot
+// knows not to reboot again if the outage is still ongoing (prevents the
+// device from rebooting in a loop when the broker / internet is just down).
+// Cleared when MQTT actually connects (re-arms the watchdog) or when the
+// reset reason is not ESP_RST_SW (WDT, panic, brownout, power-on).
+RTC_DATA_ATTR static bool g_connection_reboot = false;
+
 // Per-phase exception accounting. The previous bare catch(...) in loop()
 // swallowed *every* C++ exception with no clue about origin, type, or
 // system state. When a single phase starts throwing every tick (typical
@@ -221,6 +229,12 @@ void setup()
   // radio TX power spikes draw current the supply can't deliver), POWERON
   // means the device actually lost power.
   g_last_reset_reason = esp_reset_reason();
+  // Only keep the "no-reboot-yet" flag across our own soft resets.
+  // Any other reset type (WDT, panic, brownout, power-on) should re-arm
+  // the watchdog so the device can recover from future connection problems.
+  if(g_last_reset_reason != ESP_RST_SW) {
+    g_connection_reboot = false;
+  }
   Serial.printf("[boot] reset_reason=%s (%d)\n", resetReasonStr(g_last_reset_reason),
                 (int)g_last_reset_reason);
   Serial.printf("[boot] heap free=%u largest_block=%u min_free=%u\n",
@@ -346,6 +360,25 @@ void loop()
   runPhase(g_phase_stats[1], []{ control->fastloop(); });
   runPhase(g_phase_stats[2], []{ wifiTick(); });
   runPhase(g_phase_stats[3], []{ fgc.loop(); });
+
+  // Connection watchdog: reboot once if the cloud has been unreachable for
+  // 15 min. g_connection_reboot prevents a reboot-loop if the outage persists
+  // after the reboot; it is cleared when MQTT actually reconnects.
+  {
+    static constexpr TickType_t CONNECTION_WATCHDOG_TICKS = 15UL * 60 * configTICK_RATE_HZ;
+    static TickType_t last_connected_tick = xTaskGetTickCount();
+    if(fgc.isConnected()) {
+      last_connected_tick = xTaskGetTickCount();
+      g_connection_reboot = false;
+    }
+    if(!g_connection_reboot && (xTaskGetTickCount() - last_connected_tick) > CONNECTION_WATCHDOG_TICKS) {
+      Serial.println("[watchdog] no cloud connection for 15 min, rebooting");
+      Serial.flush();
+      g_connection_reboot = true;
+      ESP.restart();
+    }
+  }
+
   esp_task_wdt_reset();
 
   if(Serial.available()) {


### PR DESCRIPTION
## Problem

After the recent reboot/leak fixes (WDT raised to 60s, aggressive `esp_task_wdt_reset()` calls everywhere), the device connects fine for ~15 min then drops the cloud connection permanently, never recovering without a manual power cycle.

**Root cause:** The previous 25s task watchdog was the *implicit* recovery mechanism — a wedged connection (half-open TCP socket, stale WiFi status, unreachable broker) would eventually block the loop long enough to trigger a panic reboot, which reconnected cleanly. The recent commits made the loop never block that long, eliminating this recovery without replacing it. Both EspMQTTClient built-in escape hatches are also inactive (`_handleWiFi=false` because the MQTT-only constructor is used; `enableDrasticResetOnConnectionFailures()` never called). The only remaining reboot in the main loop is the low-heap restart — it never fires when the heap is fine but the connection is wedged.

The secondary aggravator: `notePublishFailure()` was tearing down **healthy WiFi** whenever 3 MQTT publishes failed (e.g. a broker hiccup). This caused unnecessary WiFi outage churn on every transient broker issue.

## Changes

### `main.cpp` — 15-min offline watchdog
- Adds a `RTC_DATA_ATTR static bool g_connection_reboot` flag that survives `ESP.restart()` but is cleared on power-on.
- After each `fgc.loop()`, if `fgc.isConnected()` → update `last_connected_tick` and clear the flag (re-arms watchdog after recovery).
- If offline >15 min and flag not set → set flag + `ESP.restart()` (one controlled reboot to recover from wedge).
- If flag already set (we rebooted and are still offline) → **no further reboots** (satisfies "no continuous reboots on broken internet").
- Any non-SW reset (WDT, panic, brownout, power-on) clears the flag in `setup()` so the watchdog is always active after an unexpected reboot.

### `fridgecloud.cpp` — remove WiFi teardown from `notePublishFailure()`
- Removes `WiFi.disconnect(false, false); WiFi.reconnect();` — this was tearing down healthy WiFi to recover a wedged MQTT socket, which widened every broker hiccup into a full WiFi outage.
- `forceDisconnect()` alone (closes the TCP socket) is sufficient; EspMQTTClient's reconnect loop opens a fresh socket.

### `fridgecloud.h` — expose `isConnected()`
- Adds `inline bool isConnected() const { return connected; }` so `main.cpp` can read the connection state.

## Behaviour after fix

| Scenario | Before fix | After fix |
|---|---|---|
| Transient outage &lt;15 min | Reconnects | Reconnects (unchanged) |
| Wedged WiFi/MQTT &gt;15 min | Stuck forever | Reboots once, reconnects |
| Broker permanently down | Stuck forever | Reboots once, then keeps retrying without further reboots |
| MQTT publish fails (broker hiccup) | WiFi torn down → wider outage | Only MQTT reconnected, WiFi untouched |

https://claude.ai/code/session_016KFEwqExmgQhw9ZQhDzNnq

---
_Generated by [Claude Code](https://claude.ai/code/session_016KFEwqExmgQhw9ZQhDzNnq)_